### PR TITLE
feat: extração de dados do Micrivox e geração de relatórios

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,13 @@
 PORT=3000
 API_KEY=sua_chave_de_api_aqui_mude_isso
 NODE_ENV=development
+
+# Evolution API (WhatsApp)
+EVOLUTION_URL=https://sua-evolution-api.com
+EVOLUTION_API_KEY=sua_chave_evolution
+EVOLUTION_INSTANCE=nome_da_instancia
+
+# Micrivox
+MICRIVOX_URL=https://app.micrivox.com.br
+MICRIVOX_API_KEY=sua_chave_micrivox
+MICRIVOX_ACCOUNT=seu_account_id_opcional

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@ const cors = require('cors');
 const https = require('https');
 const http = require('http');
 const { URL } = require('url');
+const { fetchCDR } = require('./micrivox');
+const { generateCDRReport, formatReportForWhatsApp } = require('./reports');
 
 const app = express();
 
@@ -124,6 +126,138 @@ app.post('/webhook', async (req, res) => {
 
     } catch (err) {
         console.error('[Claudio] Erro inesperado:', err.message);
+    }
+});
+
+/**
+ * Valida e normaliza uma data no formato YYYY-MM-DD.
+ * Retorna null se inválida.
+ */
+function parseDate(value) {
+    if (!value || typeof value !== 'string') return null;
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+    const d = new Date(value);
+    if (isNaN(d.getTime())) return null;
+    return value;
+}
+
+/**
+ * Rota: Gerar relatório de chamadas do Micrivox (retorna JSON)
+ *
+ * Body: { startDate: "YYYY-MM-DD", endDate: "YYYY-MM-DD" }
+ * Header: apikey
+ */
+app.post('/report/generate', async (req, res) => {
+    const apikey = req.headers['apikey'] || req.headers['x-apikey'];
+    if (!apikey || apikey !== API_KEY) {
+        return res.status(401).json({ error: 'Não autorizado.' });
+    }
+
+    const startDate = parseDate(req.body.startDate);
+    const endDate = parseDate(req.body.endDate);
+
+    if (!startDate || !endDate) {
+        return res.status(400).json({
+            error: 'Campos obrigatórios: startDate e endDate (formato YYYY-MM-DD).',
+        });
+    }
+
+    if (startDate > endDate) {
+        return res.status(400).json({ error: 'startDate não pode ser posterior a endDate.' });
+    }
+
+    try {
+        const records = await fetchCDR(startDate, endDate);
+        const report = generateCDRReport(records, { startDate, endDate });
+        return res.status(200).json({ status: 'success', report });
+    } catch (err) {
+        console.error('[Claudio] Erro ao gerar relatório Micrivox:', err.message);
+        return res.status(502).json({ error: 'Erro ao buscar dados do Micrivox.', detail: err.message });
+    }
+});
+
+/**
+ * Rota: Gerar relatório e enviar via WhatsApp
+ *
+ * Body: { startDate: "YYYY-MM-DD", endDate: "YYYY-MM-DD", phone: "5511999999999" }
+ * Header: apikey
+ */
+app.post('/report/send', async (req, res) => {
+    const apikey = req.headers['apikey'] || req.headers['x-apikey'];
+    if (!apikey || apikey !== API_KEY) {
+        return res.status(401).json({ error: 'Não autorizado.' });
+    }
+
+    const startDate = parseDate(req.body.startDate);
+    const endDate = parseDate(req.body.endDate);
+    const phone = req.body.phone || req.body.number;
+
+    const errors = [];
+    if (!startDate || !endDate) errors.push('Campos obrigatórios: startDate e endDate (formato YYYY-MM-DD).');
+    if (startDate && endDate && startDate > endDate) errors.push('startDate não pode ser posterior a endDate.');
+    if (!phone || typeof phone !== 'string' || phone.trim() === '') errors.push('Campo obrigatório: phone.');
+
+    if (errors.length > 0) {
+        return res.status(400).json({ error: 'Validação falhou', details: errors });
+    }
+
+    // Resposta imediata para evitar timeout
+    res.status(200).json({
+        status: 'success',
+        message: 'Relatório sendo gerado e enviado ao WhatsApp...',
+        timestamp: new Date().toISOString(),
+    });
+
+    // Processamento assíncrono
+    try {
+        const records = await fetchCDR(startDate, endDate);
+        const report = generateCDRReport(records, { startDate, endDate });
+        const message = formatReportForWhatsApp(report);
+
+        if (!EVOLUTION_URL || !EVOLUTION_API_KEY || !EVOLUTION_INSTANCE) {
+            console.error('[Claudio] Variáveis de ambiente da Evolution API não configuradas.');
+            return;
+        }
+
+        let parsedUrl;
+        try {
+            parsedUrl = new URL(`${EVOLUTION_URL}/message/sendText/${EVOLUTION_INSTANCE}`);
+        } catch (err) {
+            console.error('[Claudio] URL inválida da Evolution API:', err.message);
+            return;
+        }
+
+        const payload = JSON.stringify({ number: phone, text: message });
+        const options = {
+            hostname: parsedUrl.hostname,
+            port: parsedUrl.port || (parsedUrl.protocol === 'https:' ? 443 : 80),
+            path: parsedUrl.pathname,
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'apikey': EVOLUTION_API_KEY,
+                'Content-Length': Buffer.byteLength(payload),
+            },
+        };
+
+        const lib = parsedUrl.protocol === 'https:' ? https : http;
+        const request = lib.request(options, (response) => {
+            let data = '';
+            response.on('data', (chunk) => { data += chunk; });
+            response.on('end', () => {
+                console.log(`[Claudio] Relatório enviado para ${phone}. Status: ${response.statusCode}`);
+            });
+        });
+
+        request.on('error', (err) => {
+            console.error('[Claudio] Erro ao enviar relatório para Evolution API:', err.message);
+        });
+
+        request.write(payload);
+        request.end();
+
+    } catch (err) {
+        console.error('[Claudio] Erro ao processar relatório Micrivox:', err.message);
     }
 });
 

--- a/src/micrivox.js
+++ b/src/micrivox.js
@@ -1,0 +1,100 @@
+const https = require('https');
+const http = require('http');
+const { URL } = require('url');
+
+const MICRIVOX_URL = process.env.MICRIVOX_URL;
+const MICRIVOX_API_KEY = process.env.MICRIVOX_API_KEY;
+const MICRIVOX_ACCOUNT = process.env.MICRIVOX_ACCOUNT;
+
+/**
+ * Faz uma requisição HTTP/HTTPS autenticada para a API do Micrivox.
+ */
+function micrivoxRequest(path, params = {}) {
+    return new Promise((resolve, reject) => {
+        if (!MICRIVOX_URL || !MICRIVOX_API_KEY) {
+            return reject(new Error('Variáveis MICRIVOX_URL e MICRIVOX_API_KEY não configuradas.'));
+        }
+
+        const query = new URLSearchParams(params).toString();
+        const fullPath = query ? `${path}?${query}` : path;
+
+        let parsedUrl;
+        try {
+            parsedUrl = new URL(MICRIVOX_URL);
+        } catch {
+            return reject(new Error('MICRIVOX_URL inválida.'));
+        }
+
+        const options = {
+            hostname: parsedUrl.hostname,
+            port: parsedUrl.port || (parsedUrl.protocol === 'https:' ? 443 : 80),
+            path: fullPath,
+            method: 'GET',
+            headers: {
+                'Authorization': `Bearer ${MICRIVOX_API_KEY}`,
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+            },
+        };
+
+        const lib = parsedUrl.protocol === 'https:' ? https : http;
+
+        const req = lib.request(options, (res) => {
+            let data = '';
+            res.on('data', (chunk) => { data += chunk; });
+            res.on('end', () => {
+                if (res.statusCode < 200 || res.statusCode >= 300) {
+                    return reject(new Error(`Micrivox retornou status ${res.statusCode}: ${data}`));
+                }
+                try {
+                    resolve(JSON.parse(data));
+                } catch {
+                    reject(new Error('Resposta da Micrivox não é JSON válido.'));
+                }
+            });
+        });
+
+        req.on('error', (err) => reject(new Error(`Erro de conexão com Micrivox: ${err.message}`)));
+        req.end();
+    });
+}
+
+/**
+ * Busca registros de CDR (Call Detail Records) do Micrivox.
+ * @param {string} startDate - Data inicial no formato YYYY-MM-DD
+ * @param {string} endDate   - Data final no formato YYYY-MM-DD
+ * @returns {Promise<Array>} Lista de registros de chamadas
+ */
+async function fetchCDR(startDate, endDate) {
+    const params = {
+        start_date: startDate,
+        end_date: endDate,
+    };
+
+    if (MICRIVOX_ACCOUNT) {
+        params.account = MICRIVOX_ACCOUNT;
+    }
+
+    const response = await micrivoxRequest('/api/v1/cdr', params);
+
+    // Normaliza diferentes formatos de resposta da API
+    if (Array.isArray(response)) return response;
+    if (response.data && Array.isArray(response.data)) return response.data;
+    if (response.records && Array.isArray(response.records)) return response.records;
+    if (response.calls && Array.isArray(response.calls)) return response.calls;
+
+    throw new Error('Formato de resposta CDR não reconhecido.');
+}
+
+/**
+ * Busca ramais/extensões cadastrados no Micrivox.
+ * @returns {Promise<Array>}
+ */
+async function fetchExtensions() {
+    const response = await micrivoxRequest('/api/v1/extensions');
+    if (Array.isArray(response)) return response;
+    if (response.data && Array.isArray(response.data)) return response.data;
+    return [];
+}
+
+module.exports = { fetchCDR, fetchExtensions };

--- a/src/reports.js
+++ b/src/reports.js
@@ -1,0 +1,198 @@
+/**
+ * Duração em segundos para string legível (ex: 01h 23m 45s)
+ */
+function formatDuration(seconds) {
+    if (!seconds || seconds <= 0) return '0s';
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = seconds % 60;
+    const parts = [];
+    if (h > 0) parts.push(`${String(h).padStart(2, '0')}h`);
+    if (m > 0 || h > 0) parts.push(`${String(m).padStart(2, '0')}m`);
+    parts.push(`${String(s).padStart(2, '0')}s`);
+    return parts.join(' ');
+}
+
+/**
+ * Determina a disposição (status) de uma chamada, normalizando diferentes formatos.
+ */
+function getDisposition(record) {
+    const raw = (record.disposition || record.status || record.state || '').toUpperCase();
+    if (raw.includes('ANSWER')) return 'ATENDIDA';
+    if (raw.includes('BUSY')) return 'OCUPADO';
+    if (raw.includes('NO ANSWER') || raw === 'NOANSWER') return 'NÃO ATENDIDA';
+    if (raw.includes('FAIL')) return 'FALHA';
+    return raw || 'DESCONHECIDA';
+}
+
+/**
+ * Extrai o ramal/número de origem de um registro CDR.
+ */
+function getSource(record) {
+    return record.src || record.caller || record.from || record.callerid || 'Desconhecido';
+}
+
+/**
+ * Extrai o destino de um registro CDR.
+ */
+function getDestination(record) {
+    return record.dst || record.destination || record.to || record.called || 'Desconhecido';
+}
+
+/**
+ * Extrai a duração efetiva (tempo falando) de um registro CDR.
+ */
+function getBillsec(record) {
+    return parseInt(record.billsec || record.talk_time || record.duration_talk || 0, 10);
+}
+
+/**
+ * Extrai a duração total (incluindo toque) de um registro CDR.
+ */
+function getTotalDuration(record) {
+    return parseInt(record.duration || record.total_duration || 0, 10);
+}
+
+/**
+ * Processa uma lista de registros CDR e retorna um objeto de relatório estruturado.
+ * @param {Array} records - Registros CDR do Micrivox
+ * @param {Object} options
+ * @param {string} options.startDate
+ * @param {string} options.endDate
+ * @returns {Object} Relatório estruturado
+ */
+function generateCDRReport(records, { startDate, endDate } = {}) {
+    if (!Array.isArray(records) || records.length === 0) {
+        return {
+            periodo: { inicio: startDate, fim: endDate },
+            resumo: { total: 0, atendidas: 0, naoAtendidas: 0, ocupado: 0, falha: 0 },
+            duracao: { totalSegundos: 0, mediaSegundos: 0 },
+            custo: { total: 0 },
+            porRamal: [],
+            porHora: {},
+            geradoEm: new Date().toISOString(),
+        };
+    }
+
+    let atendidas = 0;
+    let naoAtendidas = 0;
+    let ocupado = 0;
+    let falha = 0;
+    let totalBillsec = 0;
+    let totalCusto = 0;
+
+    const porRamal = {};
+    const porHora = {};
+
+    for (const rec of records) {
+        const disposicao = getDisposition(rec);
+        const src = getSource(rec);
+        const billsec = getBillsec(rec);
+        const duration = getTotalDuration(rec);
+        const custo = parseFloat(rec.cost || rec.valor || rec.price || 0);
+
+        // Contagem por disposição
+        if (disposicao === 'ATENDIDA') atendidas++;
+        else if (disposicao === 'NÃO ATENDIDA') naoAtendidas++;
+        else if (disposicao === 'OCUPADO') ocupado++;
+        else falha++;
+
+        totalBillsec += billsec;
+        totalCusto += custo;
+
+        // Agrupamento por ramal de origem
+        if (!porRamal[src]) {
+            porRamal[src] = { ramal: src, total: 0, atendidas: 0, duracaoSegundos: 0, custo: 0 };
+        }
+        porRamal[src].total++;
+        if (disposicao === 'ATENDIDA') porRamal[src].atendidas++;
+        porRamal[src].duracaoSegundos += billsec;
+        porRamal[src].custo += custo;
+
+        // Agrupamento por hora do dia
+        const hora = extrairHora(rec);
+        if (hora !== null) {
+            if (!porHora[hora]) porHora[hora] = 0;
+            porHora[hora]++;
+        }
+    }
+
+    const total = records.length;
+    const ramaisOrdenados = Object.values(porRamal)
+        .sort((a, b) => b.total - a.total)
+        .slice(0, 10);
+
+    return {
+        periodo: { inicio: startDate, fim: endDate },
+        resumo: { total, atendidas, naoAtendidas, ocupado, falha },
+        duracao: {
+            totalSegundos: totalBillsec,
+            mediaSegundos: total > 0 ? Math.round(totalBillsec / atendidas || 0) : 0,
+        },
+        custo: { total: parseFloat(totalCusto.toFixed(2)) },
+        porRamal: ramaisOrdenados,
+        porHora,
+        geradoEm: new Date().toISOString(),
+    };
+}
+
+/**
+ * Extrai a hora (0–23) de um registro CDR.
+ */
+function extrairHora(record) {
+    const raw = record.calldate || record.start_time || record.datetime || record.date || null;
+    if (!raw) return null;
+    try {
+        return new Date(raw).getHours();
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Formata o relatório estruturado como texto para envio via WhatsApp.
+ * @param {Object} report - Retorno de generateCDRReport
+ * @returns {string}
+ */
+function formatReportForWhatsApp(report) {
+    const { periodo, resumo, duracao, custo, porRamal } = report;
+
+    const taxaAtendimento = resumo.total > 0
+        ? ((resumo.atendidas / resumo.total) * 100).toFixed(1)
+        : '0.0';
+
+    const linhas = [
+        `*RELATÓRIO DE LIGAÇÕES - MICRIVOX*`,
+        `Período: ${periodo.inicio || '?'} a ${periodo.fim || '?'}`,
+        ``,
+        `*RESUMO GERAL*`,
+        `Total de chamadas: ${resumo.total}`,
+        `Atendidas: ${resumo.atendidas} (${taxaAtendimento}%)`,
+        `Não atendidas: ${resumo.naoAtendidas}`,
+        `Ocupado: ${resumo.ocupado}`,
+        `Falhas: ${resumo.falha}`,
+        ``,
+        `*DURAÇÃO*`,
+        `Tempo total (falando): ${formatDuration(duracao.totalSegundos)}`,
+        `Média por atendida: ${formatDuration(duracao.mediaSegundos)}`,
+    ];
+
+    if (custo.total > 0) {
+        linhas.push(``, `*CUSTO*`, `Total: R$ ${custo.total.toFixed(2)}`);
+    }
+
+    if (porRamal.length > 0) {
+        linhas.push(``, `*TOP RAMAIS*`);
+        porRamal.slice(0, 5).forEach((r, i) => {
+            linhas.push(
+                `${i + 1}. Ramal ${r.ramal}: ${r.total} chamadas (${r.atendidas} atendidas) — ${formatDuration(r.duracaoSegundos)}`
+            );
+        });
+    }
+
+    linhas.push(``, `_Gerado em: ${new Date(report.geradoEm).toLocaleString('pt-BR')}_`);
+
+    return linhas.join('\n');
+}
+
+module.exports = { generateCDRReport, formatReportForWhatsApp, formatDuration };


### PR DESCRIPTION
$(cat <<'EOF'
## Resumo

- Integração com a API do Micrivox para busca de CDR (Call Detail Records)
- Geração de relatórios estruturados com métricas de chamadas
- Envio automático de relatórios via WhatsApp (Evolution API)

## O que foi adicionado

### `src/micrivox.js`
Cliente HTTP para a API do Micrivox:
- `fetchCDR(startDate, endDate)` — busca registros de chamadas por período
- `fetchExtensions()` — lista ramais cadastrados
- Autenticação via Bearer token, normalização de diferentes formatos de resposta

### `src/reports.js`
Geração e formatação de relatórios:
- `generateCDRReport(records)` — processa CDR e retorna relatório estruturado com: resumo (total, atendidas, não atendidas, ocupado, falha), duração total/média, custo, top 10 ramais e distribuição por hora
- `formatReportForWhatsApp(report)` — formata o relatório como texto com markdown do WhatsApp

### `src/index.js` — Novas rotas (autenticadas por `apikey`)
| Rota | Método | Descrição |
|---|---|---|
| `POST /report/generate` | POST | Gera relatório e retorna JSON |
| `POST /report/send` | POST | Gera relatório e envia via WhatsApp |

**Body esperado:**
```json
{
  "startDate": "2025-05-01",
  "endDate": "2025-05-14",
  "phone": "5511999999999"
}
```

### `.env.example`
Variáveis Micrivox documentadas:
```
MICRIVOX_URL=https://app.micrivox.com.br
MICRIVOX_API_KEY=sua_chave_micrivox
MICRIVOX_ACCOUNT=seu_account_id_opcional
```

## Plano de teste

- [ ] Configurar `.env` com credenciais reais do Micrivox
- [ ] Testar `POST /report/generate` com datas válidas e verificar JSON retornado
- [ ] Testar `POST /report/send` e confirmar recebimento do relatório no WhatsApp
- [ ] Testar validações: datas inválidas, campos faltando, apikey errada

https://claude.ai/code/session_01NmNqE6MiK9MYCDmuDkprpM
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmNqE6MiK9MYCDmuDkprpM)_